### PR TITLE
feat: 非ログインユーザー向けいいねボタン実装

### DIFF
--- a/app/api/like/[id]/route.ts
+++ b/app/api/like/[id]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { fetchFromMicroCMS, patchMicroCMS, isMicroCMSEnabled } from '@/lib/microcms/client'
+
+export const dynamic = 'force-dynamic'
+
+// Only allow alphanumeric, hyphens, and underscores to prevent path traversal
+const VALID_ID = /^[a-zA-Z0-9_-]+$/
+
+interface MicroCMSLikeEntry {
+  id: string
+  likeCount?: number
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  if (!VALID_ID.test(id)) {
+    return NextResponse.json({ error: 'Invalid article ID' }, { status: 400 })
+  }
+
+  if (!isMicroCMSEnabled()) {
+    return NextResponse.json({ error: 'microCMS not configured' }, { status: 503 })
+  }
+
+  const cookieStore = await cookies()
+  const cookieName = `liked_${id}`
+
+  if (cookieStore.get(cookieName)) {
+    return NextResponse.json({ error: 'Already liked' }, { status: 409 })
+  }
+
+  let currentCount: number
+  try {
+    const entry = await fetchFromMicroCMS<MicroCMSLikeEntry>(`blog/${id}`, {
+      cache: 'no-store',
+    })
+    currentCount = entry.likeCount ?? 0
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch article' }, { status: 502 })
+  }
+
+  const newCount = currentCount + 1
+
+  try {
+    await patchMicroCMS(`blog/${id}`, { likeCount: newCount })
+  } catch {
+    return NextResponse.json({ error: 'Failed to update like count' }, { status: 502 })
+  }
+
+  const response = NextResponse.json({ likeCount: newCount })
+  response.cookies.set(cookieName, '1', {
+    httpOnly: false, // Client-readable so LikeButton can restore liked state on mount
+    sameSite: 'strict',
+    maxAge: 60 * 60 * 24 * 365, // 1 year
+    path: '/',
+    secure: process.env.NODE_ENV === 'production',
+  })
+
+  return response
+}

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+interface LikeButtonProps {
+  articleId: string
+  initialCount: number
+}
+
+export default function LikeButton({ articleId, initialCount }: LikeButtonProps) {
+  const [count, setCount] = useState(initialCount)
+  const [liked, setLiked] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [animate, setAnimate] = useState(false)
+
+  useEffect(() => {
+    const cookieName = `liked_${articleId}`
+    const hasLiked = document.cookie.split(';').some((c) => c.trim().startsWith(`${cookieName}=`))
+    setLiked(hasLiked)
+  }, [articleId])
+
+  const handleLike = async () => {
+    if (liked || isLoading) return
+
+    setIsLoading(true)
+    try {
+      const res = await fetch(`/api/like/${articleId}`, { method: 'POST' })
+      if (res.ok) {
+        const data = (await res.json()) as { likeCount: number }
+        setCount(data.likeCount)
+        setLiked(true)
+        setAnimate(true)
+        setTimeout(() => setAnimate(false), 300)
+      }
+    } catch {
+      // Like button is non-critical; silently ignore network errors
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleLike}
+      disabled={liked || isLoading}
+      aria-label={liked ? 'いいね済み' : 'いいね'}
+      className={[
+        'flex items-center gap-1.5 rounded-full px-4 py-2 text-sm font-medium transition-all duration-200',
+        liked
+          ? 'cursor-default bg-pink-100 text-pink-600 dark:bg-pink-900/40 dark:text-pink-400'
+          : 'cursor-pointer bg-gray-100 text-gray-500 hover:bg-pink-50 hover:text-pink-500 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-pink-900/30 dark:hover:text-pink-400',
+        isLoading ? 'opacity-60' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <span
+        className={[
+          'inline-block transition-transform duration-150',
+          animate ? 'scale-125' : 'scale-100',
+        ].join(' ')}
+        aria-hidden="true"
+      >
+        {liked ? '❤️' : '🤍'}
+      </span>
+      <span>{count}</span>
+    </button>
+  )
+}

--- a/layouts/MicroCMSPostLayout.tsx
+++ b/layouts/MicroCMSPostLayout.tsx
@@ -10,6 +10,7 @@ import siteMetadata from '@/data/siteMetadata'
 import Comments from '@/components/Comments'
 import MicroCMSCodeEnhancer from '@/components/MicroCMSCodeEnhancer'
 import EmbedContent from '@/components/EmbedContent'
+import LikeButton from '@/components/LikeButton'
 
 const formatDateYYMMDD = (value: string) => {
   const date = new Date(value)
@@ -29,7 +30,7 @@ interface MicroCMSPostLayoutProps {
 }
 
 export default function MicroCMSPostLayout({ post, prev, next }: MicroCMSPostLayoutProps) {
-  const { slug, title, tags, createdAt, revisedAt, contentHtml, heroImage } = post
+  const { slug, title, tags, createdAt, revisedAt, contentHtml, heroImage, likeCount } = post
 
   return (
     <SectionContainer>
@@ -79,6 +80,9 @@ export default function MicroCMSPostLayout({ post, prev, next }: MicroCMSPostLay
               ) : (
                 <div className="prose dark:prose-invert max-w-none pt-10 pb-8" />
               )}
+              <div className="flex justify-center pt-8 pb-2">
+                <LikeButton articleId={slug} initialCount={likeCount ?? 0} />
+              </div>
               {siteMetadata.comments && (
                 <div
                   className="pt-6 pb-6 text-center text-gray-700 dark:text-gray-300"

--- a/lib/microcms/client.ts
+++ b/lib/microcms/client.ts
@@ -29,3 +29,26 @@ export async function fetchFromMicroCMS<T>(endpoint: string, init?: RequestInit)
 
   return (await response.json()) as T
 }
+
+export async function patchMicroCMS<T extends Record<string, unknown>>(
+  endpoint: string,
+  body: T
+): Promise<void> {
+  if (!isMicroCMSEnabled()) {
+    throw new Error('MicroCMS environment variables are not configured.')
+  }
+
+  const response = await fetch(`${baseUrl}/${endpoint}`, {
+    method: 'PATCH',
+    headers: {
+      'X-MICROCMS-API-KEY': apiKey as string,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const errorBody = await response.text()
+    throw new Error(`Failed to patch microCMS: ${response.status} ${errorBody}`)
+  }
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -32,6 +32,7 @@ interface MicroCMSBlogEntry {
   overwrotePublishedAt?: string
   createdAt: string
   updatedAt: string
+  likeCount?: number
 }
 
 interface MicroCMSAboutEntry {
@@ -52,6 +53,7 @@ export interface BlogListItem {
   createdAt: string
   revisedAt?: string
   heroImage?: MicroCMSMedia | string | null
+  likeCount?: number
 }
 
 export interface MicroCMSBlogDetail extends BlogListItem {
@@ -114,6 +116,7 @@ const mapMicroCMSToListItem = (entry: MicroCMSBlogEntry): BlogListItem => {
     createdAt,
     revisedAt,
     heroImage: entry.thumbnail || null,
+    likeCount: entry.likeCount ?? 0,
   }
 }
 


### PR DESCRIPTION
## 概要

note.com 風の非ログインユーザー向けいいねボタンを実装します。
microCMS の API キーはサーバーサイドのみで使用し、クライアントには一切露出しません。

## 変更内容

### microCMS 側（手動対応が必要）
- `blog` コンテンツ型に **`likeCount`（数値）** フィールドを追加してください
- 初期値は `0`、必須なし

### 追加・変更ファイル

| ファイル | 種別 | 内容 |
|---|---|---|
| `app/api/like/[id]/route.ts` | 新規 | いいね POST エンドポイント |
| `components/LikeButton.tsx` | 新規 | ハートアニメーション付きボタン (Client Component) |
| `layouts/MicroCMSPostLayout.tsx` | 変更 | LikeButton を記事本文直下に組み込み |
| `lib/microcms/client.ts` | 変更 | `patchMicroCMS()` 関数を追加 |
| `lib/posts.ts` | 変更 | `likeCount` フィールドを型定義・マッピングに追加 |

## 処理フロー

```
[ブラウザ] POST /api/like/{id}
    ↓
[API Route (サーバー)]
  1. ID バリデーション（英数字・ハイフンのみ）
  2. Cookie liked_{id} の二重いいねチェック
  3. microCMS GET で現在の likeCount を取得（cache: no-store）
  4. microCMS PATCH で likeCount + 1
  5. Set-Cookie: liked_{id}=1（SameSite=Strict, 1年）
  6. 新しい likeCount を JSON で返却
    ↓
[LikeButton (Client)]
  - レスポンスを受けてカウント楽観的更新
  - ハートアイコンスケールアニメーション
```

## セキュリティポイント

- `MICROCMS_API_KEY` は `server-only` モジュール経由のサーバー限定、クライアントに露出しない
- Cookie は `SameSite=Strict` + 本番環境では `Secure` フラグ
- ID は正規表現 `/^[a-zA-Z0-9_-]+$/` でパストラバーサル対策済み

## UI

- 未いいね：グレー背景 `🤍 12`
- いいね済み：ピンク背景 `❤️ 13`（ボタン disabled）
- 押下時：ハートが `scale-125` → `scale-100` アニメーション
- ダークモード対応済み
- マウント時に Cookie を読んで「いいね済み」状態を復元

## 既知の制限

microCMS はアトミックなインクリメント操作を提供しないため、同時アクセスが重なると稀にカウントが1ずれる可能性があります。個人ブログのユースケースでは許容範囲と判断しています。

https://claude.ai/code/session_01SAkZk5s7UgqaViF5mNxBsr