### PR TITLE
feat: メルマガ機能（メアド登録・新規投稿通知メール）

### DIFF
--- a/app/api/newsletter/subscribe/route.ts
+++ b/app/api/newsletter/subscribe/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Resend } from 'resend'
+
+export const dynamic = 'force-dynamic'
+
+// Intentionally loose — we let Resend do the authoritative validation.
+// This guards against obviously malformed input before hitting the network.
+const EMAIL_RE = /^[^\s@]{1,64}@[^\s@]{1,255}\.[^\s@]{2,}$/
+
+export async function POST(req: NextRequest) {
+  const apiKey = process.env.RESEND_API_KEY
+  const audienceId = process.env.RESEND_AUDIENCE_ID
+
+  if (!apiKey || !audienceId) {
+    return NextResponse.json({ error: 'Newsletter not configured' }, { status: 503 })
+  }
+
+  let email: string
+  try {
+    const body: unknown = await req.json()
+    if (!body || typeof body !== 'object' || !('email' in body)) {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+    }
+    email = String((body as Record<string, unknown>).email)
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  email = email.trim().toLowerCase()
+
+  if (!EMAIL_RE.test(email)) {
+    return NextResponse.json({ error: 'Invalid email address' }, { status: 422 })
+  }
+
+  const resend = new Resend(apiKey)
+
+  try {
+    await resend.contacts.create({ audienceId, email, unsubscribed: false })
+  } catch (err) {
+    // Resend returns a 409-like error when the contact already exists.
+    // Treat this as success to avoid email enumeration.
+    const msg = err instanceof Error ? err.message : String(err)
+    if (!msg.toLowerCase().includes('already')) {
+      console.error('[newsletter/subscribe] failed:', err)
+      return NextResponse.json({ error: 'Failed to subscribe' }, { status: 502 })
+    }
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/newsletter/unsubscribe/route.ts
+++ b/app/api/newsletter/unsubscribe/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createHmac, timingSafeEqual } from 'crypto'
+import { Resend } from 'resend'
+
+export const dynamic = 'force-dynamic'
+
+const EMAIL_RE = /^[^\s@]{1,64}@[^\s@]{1,255}\.[^\s@]{2,}$/
+
+function verifyToken(email: string, token: string): boolean {
+  const secret = process.env.RESEND_UNSUBSCRIBE_SECRET
+  if (!secret) return false
+  const expected = createHmac('sha256', secret).update(email).digest('hex')
+  if (token.length !== expected.length) return false
+  try {
+    return timingSafeEqual(Buffer.from(token, 'hex'), Buffer.from(expected, 'hex'))
+  } catch {
+    return false
+  }
+}
+
+const htmlPage = (heading: string, body: string) => `<!DOCTYPE html>
+<html lang="ja"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${heading}</title>
+<style>body{font-family:sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#f9fafb}
+.card{background:#fff;border-radius:8px;padding:40px;max-width:400px;text-align:center;box-shadow:0 1px 3px rgba(0,0,0,.1)}
+h1{margin:0 0 12px;font-size:22px;color:#111}p{color:#555;margin:0 0 20px}a{color:#0070f3}</style>
+</head><body><div class="card"><h1>${heading}</h1><p>${body}</p></div></body></html>`
+
+// GET — linked from unsubscribe link in email
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const email = (searchParams.get('email') ?? '').trim().toLowerCase()
+  const token = searchParams.get('token') ?? ''
+
+  if (!EMAIL_RE.test(email) || !token) {
+    return new NextResponse(htmlPage('無効なリンク', '配信停止リンクが無効です。'), {
+      status: 400,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    })
+  }
+
+  if (!verifyToken(email, token)) {
+    return new NextResponse(htmlPage('無効なリンク', '配信停止リンクが無効または期限切れです。'), {
+      status: 400,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    })
+  }
+
+  const apiKey = process.env.RESEND_API_KEY
+  const audienceId = process.env.RESEND_AUDIENCE_ID
+
+  if (!apiKey || !audienceId) {
+    return new NextResponse(
+      htmlPage('エラー', 'サーバーの設定に問題があります。しばらく経ってからお試しください。'),
+      { status: 503, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+    )
+  }
+
+  try {
+    const resend = new Resend(apiKey)
+    await resend.contacts.remove({ audienceId, email })
+  } catch (err) {
+    console.error('[newsletter/unsubscribe] failed:', err)
+    return new NextResponse(
+      htmlPage('エラー', '配信停止処理に失敗しました。しばらく経ってからお試しください。'),
+      { status: 502, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+    )
+  }
+
+  return new NextResponse(
+    htmlPage('配信停止しました', 'メルマガの配信を停止しました。またいつでも再登録できます。'),
+    { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+  )
+}

--- a/app/api/newsletter/webhook/route.ts
+++ b/app/api/newsletter/webhook/route.ts
@@ -1,0 +1,188 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createHmac, timingSafeEqual } from 'crypto'
+import { Resend } from 'resend'
+import { fetchFromMicroCMS, isMicroCMSEnabled } from '@/lib/microcms/client'
+import siteMetadata from '@/data/siteMetadata'
+
+export const dynamic = 'force-dynamic'
+
+// Resend batch.send accepts up to 100 emails per call
+const BATCH_SIZE = 100
+
+interface MicroCMSWebhookBody {
+  api?: string
+  id?: string
+  type?: string
+  contents?: {
+    new?: {
+      id?: string
+      publishStatus?: string
+    }
+  }
+}
+
+interface MicroCMSArticle {
+  id: string
+  title: string
+}
+
+interface ResendContact {
+  email: string
+  unsubscribed: boolean
+}
+
+function verifySecret(raw: string, expected: string): boolean {
+  if (raw.length !== expected.length) return false
+  try {
+    return timingSafeEqual(Buffer.from(raw), Buffer.from(expected))
+  } catch {
+    return false
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+}
+
+function buildEmailHtml(title: string, articleUrl: string, unsubscribeUrl: string): string {
+  const safeTitle = escapeHtml(title)
+  const safeArticleUrl = escapeHtml(articleUrl)
+  const safeUnsubUrl = escapeHtml(unsubscribeUrl)
+
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f9fafb;font-family:sans-serif">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f9fafb;padding:32px 0">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:8px;padding:40px;max-width:100%">
+        <tr><td>
+          <h1 style="margin:0 0 8px;font-size:20px;color:#111">新しい記事が公開されました</h1>
+          <p style="margin:0 0 24px;font-size:18px;font-weight:600;color:#222">${safeTitle}</p>
+          <a href="${safeArticleUrl}"
+             style="display:inline-block;padding:12px 24px;background:#0070f3;color:#fff;text-decoration:none;border-radius:6px;font-size:15px;font-weight:500">
+            記事を読む
+          </a>
+          <hr style="margin:40px 0 24px;border:none;border-top:1px solid #eee">
+          <p style="margin:0;font-size:12px;color:#999">
+            このメールは <a href="${escapeHtml(siteMetadata.siteUrl)}" style="color:#999">${escapeHtml(siteMetadata.siteUrl)}</a> のメルマガに登録されたアドレスへ送信しています。<br>
+            配信停止は<a href="${safeUnsubUrl}" style="color:#999">こちら</a>
+          </p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`
+}
+
+function makeUnsubscribeUrl(email: string): string {
+  const secret = process.env.RESEND_UNSUBSCRIBE_SECRET
+  if (!secret) return siteMetadata.siteUrl
+  const token = createHmac('sha256', secret).update(email).digest('hex')
+  return `${siteMetadata.siteUrl}/api/newsletter/unsubscribe?email=${encodeURIComponent(email)}&token=${token}`
+}
+
+export async function POST(req: NextRequest) {
+  // --- Auth ---
+  const webhookSecret = process.env.MICROCMS_WEBHOOK_SECRET
+  if (!webhookSecret) {
+    console.error('[newsletter/webhook] MICROCMS_WEBHOOK_SECRET is not set')
+    return NextResponse.json({ error: 'Server misconfiguration' }, { status: 500 })
+  }
+
+  const incoming = req.headers.get('x-webhook-secret') ?? ''
+  if (!verifySecret(incoming, webhookSecret)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // --- Parse body ---
+  let body: MicroCMSWebhookBody
+  try {
+    body = (await req.json()) as MicroCMSWebhookBody
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  // Only handle new blog publications
+  if (body.api !== 'blog' || body.type !== 'new') {
+    return NextResponse.json({ ok: true, skipped: true })
+  }
+
+  const contentId = body.id ?? body.contents?.new?.id
+  if (!contentId || !/^[a-zA-Z0-9_-]+$/.test(contentId)) {
+    return NextResponse.json({ error: 'Missing or invalid content id' }, { status: 400 })
+  }
+
+  // --- Dependencies check ---
+  const apiKey = process.env.RESEND_API_KEY
+  const audienceId = process.env.RESEND_AUDIENCE_ID
+  const fromEmail = process.env.RESEND_FROM_EMAIL
+
+  if (!apiKey || !audienceId || !fromEmail) {
+    console.error('[newsletter/webhook] Resend env vars missing')
+    return NextResponse.json({ error: 'Newsletter not configured' }, { status: 503 })
+  }
+
+  if (!isMicroCMSEnabled()) {
+    return NextResponse.json({ error: 'microCMS not configured' }, { status: 503 })
+  }
+
+  // --- Fetch article title from microCMS ---
+  let article: MicroCMSArticle
+  try {
+    article = await fetchFromMicroCMS<MicroCMSArticle>(`blog/${contentId}`, { cache: 'no-store' })
+  } catch (err) {
+    console.error('[newsletter/webhook] failed to fetch article:', err)
+    return NextResponse.json({ error: 'Failed to fetch article' }, { status: 502 })
+  }
+
+  const articleUrl = `${siteMetadata.siteUrl}/blog/${contentId}`
+
+  // --- Fetch subscribers ---
+  const resend = new Resend(apiKey)
+  let contacts: ResendContact[]
+  try {
+    const result = await resend.contacts.list({ audienceId })
+    contacts = ((result.data as { data?: ResendContact[] } | null)?.data ?? []).filter(
+      (c) => !c.unsubscribed
+    )
+  } catch (err) {
+    console.error('[newsletter/webhook] failed to list contacts:', err)
+    return NextResponse.json({ error: 'Failed to fetch subscribers' }, { status: 502 })
+  }
+
+  if (contacts.length === 0) {
+    return NextResponse.json({ ok: true, sent: 0 })
+  }
+
+  // --- Send in batches of BATCH_SIZE ---
+  let totalSent = 0
+  for (let i = 0; i < contacts.length; i += BATCH_SIZE) {
+    const chunk = contacts.slice(i, i + BATCH_SIZE)
+    const emails = chunk.map((c) => ({
+      from: fromEmail,
+      to: c.email,
+      subject: `新しい記事: ${article.title}`,
+      html: buildEmailHtml(article.title, articleUrl, makeUnsubscribeUrl(c.email)),
+    }))
+
+    try {
+      await resend.batch.send(emails)
+      totalSent += chunk.length
+    } catch (err) {
+      console.error(`[newsletter/webhook] batch send failed at offset ${i}:`, err)
+      return NextResponse.json(
+        { error: 'Partial send failure', sent: totalSent },
+        { status: 502 }
+      )
+    }
+  }
+
+  return NextResponse.json({ ok: true, sent: totalSent })
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,11 +1,13 @@
 import Link from './Link'
 import siteMetadata from '@/data/siteMetadata'
 import SocialIcon from '@/components/social-icons'
+import NewsletterForm from '@/components/NewsletterForm'
 
 export default function Footer() {
   return (
     <footer>
       <div className="mt-16 flex flex-col items-center">
+        <NewsletterForm />
         <div className="mb-3 flex space-x-4">
           {/* <SocialIcon kind="mail" href={`mailto:${siteMetadata.email}`} size={6} /> */}
           <SocialIcon

--- a/components/NewsletterForm.tsx
+++ b/components/NewsletterForm.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useState } from 'react'
+
+type State = 'idle' | 'loading' | 'success' | 'error'
+
+export default function NewsletterForm() {
+  const [email, setEmail] = useState('')
+  const [state, setState] = useState<State>('idle')
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (state === 'loading') return
+    setState('loading')
+
+    try {
+      const res = await fetch('/api/newsletter/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      })
+      setState(res.ok ? 'success' : 'error')
+    } catch {
+      setState('error')
+    }
+  }
+
+  if (state === 'success') {
+    return (
+      <div className="mb-6 text-center">
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          ✓ 登録しました！新しい記事の通知をお送りします。
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mb-6">
+      <p className="mb-2 text-center text-sm text-gray-500 dark:text-gray-400">
+        新着記事をメールで受け取る
+      </p>
+      <form onSubmit={handleSubmit} className="flex flex-col items-center gap-2 sm:flex-row">
+        <label htmlFor="newsletter-email" className="sr-only">
+          メールアドレス
+        </label>
+        <input
+          id="newsletter-email"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="メールアドレス"
+          className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500 sm:w-64"
+          disabled={state === 'loading'}
+        />
+        <button
+          type="submit"
+          disabled={state === 'loading'}
+          className="w-full rounded-md bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+        >
+          {state === 'loading' ? '登録中…' : '登録する'}
+        </button>
+      </form>
+      {state === 'error' && (
+        <p className="mt-2 text-center text-xs text-red-500">
+          エラーが発生しました。しばらくしてから再試行してください。
+        </p>
+      )}
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "remark-gfm": "^4.0.0",
         "remark-github-blockquote-alert": "^1.2.1",
         "remark-math": "^6.0.0",
+        "resend": "^6.12.0",
         "tailwindcss": "^4.0.5",
         "unist-util-visit": "^5.0.0",
         "vaul": "^1.1.2"
@@ -4816,6 +4817,12 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -9031,6 +9038,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -13745,6 +13758,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -15103,6 +15122,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resend": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.0.tgz",
+      "integrity": "sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -15721,6 +15761,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -16169,6 +16219,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/sync-fetch": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "remark-gfm": "^4.0.0",
     "remark-github-blockquote-alert": "^1.2.1",
     "remark-math": "^6.0.0",
+    "resend": "^6.12.0",
     "tailwindcss": "^4.0.5",
     "unist-util-visit": "^5.0.0",
     "vaul": "^1.1.2"


### PR DESCRIPTION
## 概要

Resend を使ったメルマガ機能を追加します。  
- フッターからメールアドレスを登録できる
- microCMS で新規記事を公開すると Webhook 経由で購読者全員にメール送信

---

## 実装内容

### 追加・変更ファイル

| ファイル | 内容 |
|---|---|
| `app/api/newsletter/subscribe/route.ts` | `POST` メアド登録。Resend Audiences にコンタクトを追加 |
| `app/api/newsletter/webhook/route.ts` | `POST` microCMS Webhook 受信。新規記事公開時のみ一斉送信 |
| `app/api/newsletter/unsubscribe/route.ts` | `GET` 配信停止。HMAC 署名トークンで本人確認してコンタクト削除 |
| `components/NewsletterForm.tsx` | フッター埋め込み用フォーム (Client Component) |
| `components/Footer.tsx` | `NewsletterForm` を追加 |
| `package.json` / `package-lock.json` | `resend@^6.12.0` を追加 |

### データフロー

```
[フッターフォーム]
  POST /api/newsletter/subscribe
    → Resend Audiences にメアド登録

[microCMS Webhook]
  POST /api/newsletter/webhook
    → X-Webhook-Secret ヘッダーで認証
    → api=blog & type=new のみ処理
    → microCMS から記事タイトルを取得
    → Resend contacts.list で購読者一覧取得
    → batch.send (100件チャンク) で一斉送信

[メール内の配信停止リンク]
  GET /api/newsletter/unsubscribe?email=xxx&token=yyy
    → HMAC-SHA256 トークン検証
    → Resend contacts.remove で削除
```

---

## セキュリティ対応

- **APIキー隠匿**: `RESEND_API_KEY` は `NEXT_PUBLIC_` 不使用。すべてのResend呼び出しはサーバーサイドのみ
- **Webhook 認証**: `X-Webhook-Secret` ヘッダーを `timingSafeEqual` でタイミング攻撃対策済み
- **配信停止トークン**: `HMAC-SHA256(email, RESEND_UNSUBSCRIBE_SECRET)` で署名、クリックリンクを推測不可能に
- **HTML インジェクション対策**: メール本文内の全ユーザーデータを `escapeHtml` で無害化
- **パストラバーサル対策**: content ID を `/^[a-zA-Z0-9_-]+$/` で検証
- **メール列挙防止**: 既登録アドレスの登録試行も `200 OK` を返す
- **audit 確認**: `resend@6.12.0` の依存グラフに新規脆弱性なし（既存16件はすべてプロジェクト既存の問題）

---

## 依存関係の注意点

`npm audit` で既存の脆弱性16件が表示されますが、これらは `resend` 追加前から存在するものです。主要なもの：

| パッケージ | 深刻度 | 備考 |
|---|---|---|
| `protobufjs` | critical | `@svgr/webpack` の推移依存 |
| `image-size` | high | `npm audit fix --force` で 2.0.2 に更新可能 |
| `flatted` | high | `flatted@^3.4.2` に更新で解消 |

`resend` 自体の依存グラフに脆弱性はありません。

---

## こちらで別途対応が必要なタスク

### 必須

- [ ] **Resend アカウント設定**
  - Resend でドメイン認証 (SPF/DKIM) を設定する
  - Audiences を作成して `RESEND_AUDIENCE_ID` を取得する
  - 送信元メールアドレス (`RESEND_FROM_EMAIL`) を Resend で承認する（例: `noreply@yourdomain.com`）

- [ ] **環境変数を Vercel に追加**（以下4つ）
  ```
  RESEND_API_KEY=re_xxxxx
  RESEND_AUDIENCE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
  RESEND_FROM_EMAIL=noreply@yourdomain.com
  RESEND_UNSUBSCRIBE_SECRET=（openssl rand -hex 32 などで生成したランダム文字列）
  MICROCMS_WEBHOOK_SECRET=（openssl rand -hex 32 などで生成したランダム文字列）
  ```

- [ ] **microCMS Webhook 設定**
  - microCMS 管理画面 → API設定 → Webhook → 追加
  - URL: `https://yourdomain.com/api/newsletter/webhook`
  - カスタムヘッダー: `X-Webhook-Secret: （上記で設定した MICROCMS_WEBHOOK_SECRET）`
  - トリガー: `公開` のみチェック（編集・削除は不要）

### 推奨

- [ ] **既存脆弱性の対応**（本PRとは独立）
  - `npm audit fix` で修正可能なものを適用
  - `image-size` は `npm audit fix --force` で 2.0.2 へ更新可能

- [ ] **Webhook 動作確認**
  - microCMS 管理画面から「Webhook送信テスト」で疎通確認
  - テスト用メアドで購読 → 記事を新規公開 → 受信確認

### 任意（将来的な改善）

- [ ] **レート制限**: 購読フォームへの連打対策（Vercel KV や Upstash Redis でIP制限）
- [ ] **登録確認メール (double opt-in)**: スパム登録対策として、登録時に確認メールを送る
- [ ] **購読者数が 100 件超えた場合**: 現実装で 100 件チャンクバッチ送信に対応済み。Resend の送信レート上限に注意

---

https://claude.ai/code/session_01SAkZk5s7UgqaViF5mNxBsr